### PR TITLE
Fix profile selection to include all profiles from toml config

### DIFF
--- a/tests/unit/test_codex_tool_multi_provider.py
+++ b/tests/unit/test_codex_tool_multi_provider.py
@@ -49,27 +49,88 @@ def test_codex_tool_multi_provider_prompts_each_provider_and_runs_selected_profi
         },
     ):
         with patch.object(tool, "_ensure_tool_installed", return_value=True):
-            # 1) pick model for ep1 (idx 0)
-            # 2) pick model for ep2 (idx 0)
-            # 3) pick profile to run => select second (idx 1) => m2
-            menu_returns = [(True, 0), (True, 0), (True, 1)]
+            with patch.object(tool, "_read_existing_profiles", return_value=[]):
+                # 1) pick model for ep1 (idx 0)
+                # 2) pick model for ep2 (idx 0)
+                # 3) pick profile to run => select second (idx 1) => m2
+                menu_returns = [(True, 0), (True, 0), (True, 1)]
 
-            with patch(
-                "code_assistant_manager.menu.menus.display_centered_menu",
-                side_effect=menu_returns,
-            ):
+                with patch(
+                    "code_assistant_manager.menu.menus.display_centered_menu",
+                    side_effect=menu_returns,
+                ):
 
-                captured = {}
+                    captured = {}
 
-                def _run(cmd, env, *_args, **_kwargs):
-                    captured["cmd"] = cmd
-                    captured["env"] = env
-                    return 0
+                    def _run(cmd, env, *_args, **_kwargs):
+                        captured["cmd"] = cmd
+                        captured["env"] = env
+                        return 0
 
-                with patch.object(tool, "_run_tool_with_env", side_effect=_run):
-                    rc = tool.run([])
+                    with patch.object(tool, "_run_tool_with_env", side_effect=_run):
+                        rc = tool.run([])
 
     assert rc == 0
     assert captured["cmd"][:3] == ["codex", "-p", "m2"]
     assert captured["env"].get("KEY2") == "k2"
     assert "NODE_TLS_REJECT_UNAUTHORIZED" in captured["env"]
+
+
+def test_codex_tool_includes_existing_profiles_from_toml(monkeypatch):
+    """Test that profile selection menu includes both existing and newly configured profiles."""
+    monkeypatch.delenv("KEY1", raising=False)
+
+    cfg = MagicMock()
+    cfg.get_sections.return_value = ["ep1"]
+
+    def _get_ep_cfg(name: str):
+        return {"api_key_env": "KEY1"}
+
+    cfg.get_endpoint_config.side_effect = _get_ep_cfg
+
+    tool = CodexTool(cfg)
+    tool.endpoint_manager = MagicMock()
+    tool.endpoint_manager._is_client_supported.return_value = True
+    tool.endpoint_manager.get_endpoint_config.return_value = (
+        True,
+        {"endpoint": "https://e1", "actual_api_key": "k1"},
+    )
+    tool.endpoint_manager.fetch_models.return_value = (True, ["new-model"])
+
+    with patch(
+        "code_assistant_manager.tools.codex.upsert_codex_profile",
+        return_value={"changed": True, "provider_existed": False, "profile_existed": False, "project_existed": False},
+    ):
+        with patch.object(tool, "_ensure_tool_installed", return_value=True):
+            with patch.object(tool, "_read_existing_profiles", return_value=["old-profile-1", "old-profile-2"]):
+                # 1) pick model for ep1 (idx 0) -> new-model
+                # 2) pick profile to run => old profiles + new profile should be shown
+                #    profiles should be: ["new-model", "old-profile-1", "old-profile-2"] (sorted)
+                #    select index 1 -> "old-profile-1"
+                menu_calls = []
+
+                def _mock_menu(prompt, options, cancel_text=None):
+                    menu_calls.append({"prompt": prompt, "options": options, "cancel_text": cancel_text})
+                    if len(menu_calls) == 1:
+                        return (True, 0)  # Select new-model
+                    else:
+                        return (True, 1)  # Select old-profile-1
+
+                with patch("code_assistant_manager.menu.menus.display_centered_menu", side_effect=_mock_menu):
+                    captured = {}
+
+                    def _run(cmd, env, *_args, **_kwargs):
+                        captured["cmd"] = cmd
+                        return 0
+
+                    with patch.object(tool, "_run_tool_with_env", side_effect=_run):
+                        rc = tool.run([])
+
+    assert rc == 0
+    assert len(menu_calls) == 2
+    # Check that profile selection includes all profiles
+    profile_menu = menu_calls[1]
+    assert profile_menu["prompt"] == "Select Codex profile to run:"
+    assert sorted(profile_menu["options"]) == ["new-model", "old-profile-1", "old-profile-2"]
+    # Verify the selected profile
+    assert captured["cmd"][:3] == ["codex", "-p", "old-profile-1"]


### PR DESCRIPTION
- Add _read_existing_profiles() to read existing profiles from ~/.codex/config.toml
- Merge existing profiles with newly configured ones in selection menu
- Users can now select from any profile in toml, not just current session
- Update tests to mock profile reading and verify behavior

Fixes: 2DEE-1C39
