### PR TITLE
feat: Update wire_api configuration to dynamically determine provider

### DIFF
--- a/code_assistant_manager/tools/codex.py
+++ b/code_assistant_manager/tools/codex.py
@@ -201,6 +201,32 @@ class CodexTool(CLITool):
                 return 0
             selected_profile = profiles[idx]
 
+        # Configure wire_api based on model type
+        from code_assistant_manager.configs import get_tool_config
+        codex_config = get_tool_config("codex")
+        if codex_config:
+            # Determine the provider for the selected profile
+            config_data = codex_config.load_config("user")
+            profile_provider = None
+            if config_data and "profiles" in config_data and selected_profile in config_data["profiles"]:
+                profile_provider = config_data["profiles"][selected_profile].get("model_provider")
+
+            if profile_provider and selected_profile.startswith("gpt"):
+                # Set wire_api to 'responses' for GPT models
+                try:
+                    codex_config.set_value(f"model_providers.{profile_provider}.wire_api", "responses", "user")
+                    print(f"[code-assistant-manager] Set codex.model_providers.{profile_provider}.wire_api = 'responses' for GPT model")
+                except Exception as e:
+                    print(f"[code-assistant-manager] Warning: Failed to set wire_api config: {e}")
+            elif profile_provider:
+                # Unset wire_api for non-GPT models
+                try:
+                    found = codex_config.unset_value(f"model_providers.{profile_provider}.wire_api", "user")
+                    if found:
+                        print(f"[code-assistant-manager] Unset codex.model_providers.{profile_provider}.wire_api for non-GPT model")
+                except Exception as e:
+                    print(f"[code-assistant-manager] Warning: Failed to unset wire_api config: {e}")
+
         env = os.environ.copy()
         if selected_profile in profile_env:
             env_key, api_key = profile_env[selected_profile]

--- a/tests/unit/test_codex_tool_multi_provider.py
+++ b/tests/unit/test_codex_tool_multi_provider.py
@@ -134,3 +134,149 @@ def test_codex_tool_includes_existing_profiles_from_toml(monkeypatch):
     assert sorted(profile_menu["options"]) == ["new-model", "old-profile-1", "old-profile-2"]
     # Verify the selected profile
     assert captured["cmd"][:3] == ["codex", "-p", "old-profile-1"]
+
+
+def test_codex_tool_sets_wire_api_by_provider_for_gpt_models(monkeypatch):
+    """Test that wire_api is set dynamically by provider name for GPT models."""
+    monkeypatch.delenv("KEY1", raising=False)
+
+    cfg = MagicMock()
+    cfg.get_sections.return_value = ["copilot-api"]
+
+    def _get_ep_cfg(name: str):
+        return {"api_key_env": "KEY1"}
+
+    cfg.get_endpoint_config.side_effect = _get_ep_cfg
+
+    tool = CodexTool(cfg)
+    tool.endpoint_manager = MagicMock()
+    tool.endpoint_manager._is_client_supported.return_value = True
+    tool.endpoint_manager.get_endpoint_config.return_value = (
+        True,
+        {"endpoint": "https://copilot.example.com", "actual_api_key": "k1"},
+    )
+    tool.endpoint_manager.fetch_models.return_value = (True, ["gpt-4", "claude-3"])
+
+    # Mock the config system
+    mock_codex_config = MagicMock()
+
+    # Mock load_config to return profile data with provider info
+    def mock_load_config(scope):
+        if scope == "user":
+            return {
+                "profiles": {
+                    "gpt-4": {"model": "gpt-4", "model_provider": "copilot-api"},
+                    "claude-3": {"model": "claude-3", "model_provider": "copilot-api"}
+                }
+            }
+        return {}
+
+    mock_codex_config.load_config.side_effect = mock_load_config
+
+    with patch(
+        "code_assistant_manager.tools.codex.upsert_codex_profile",
+        return_value={"changed": True, "provider_existed": False, "profile_existed": False, "project_existed": False},
+    ):
+        with patch.object(tool, "_ensure_tool_installed", return_value=True):
+            with patch.object(tool, "_read_existing_profiles", return_value=[]):
+                with patch("code_assistant_manager.configs.get_tool_config", return_value=mock_codex_config):
+                    # Mock all menu interactions
+                    menu_calls = []
+
+                    def mock_select_multiple_models(models, prompt, cancel_text=None):
+                        menu_calls.append({"type": "select_multiple", "models": models, "prompt": prompt})
+                        # Select gpt-4 (index 0)
+                        return True, ["gpt-4"]
+
+                    def mock_display_centered_menu(prompt, options, cancel_text=None):
+                        menu_calls.append({"type": "display_centered", "prompt": prompt, "options": options})
+                        # Select gpt-4 profile (should be index 0)
+                        return True, 0
+
+                    with patch("code_assistant_manager.menu.menus.select_multiple_models", side_effect=mock_select_multiple_models):
+                        with patch("code_assistant_manager.menu.menus.display_centered_menu", side_effect=mock_display_centered_menu):
+                            captured = {}
+
+                            def _run(cmd, env, *_args, **_kwargs):
+                                captured["cmd"] = cmd
+                                return 0
+
+                            with patch.object(tool, "_run_tool_with_env", side_effect=_run):
+                                rc = tool.run([])
+
+    assert rc == 0
+    # Verify wire_api was set for the correct provider
+    mock_codex_config.set_value.assert_called_with("model_providers.copilot-api.wire_api", "responses", "user")
+
+
+def test_codex_tool_unsets_wire_api_by_provider_for_non_gpt_models(monkeypatch):
+    """Test that wire_api is unset dynamically by provider name for non-GPT models."""
+    monkeypatch.delenv("KEY1", raising=False)
+
+    cfg = MagicMock()
+    cfg.get_sections.return_value = ["copilot-api"]
+
+    def _get_ep_cfg(name: str):
+        return {"api_key_env": "KEY1"}
+
+    cfg.get_endpoint_config.side_effect = _get_ep_cfg
+
+    tool = CodexTool(cfg)
+    tool.endpoint_manager = MagicMock()
+    tool.endpoint_manager._is_client_supported.return_value = True
+    tool.endpoint_manager.get_endpoint_config.return_value = (
+        True,
+        {"endpoint": "https://copilot.example.com", "actual_api_key": "k1"},
+    )
+    tool.endpoint_manager.fetch_models.return_value = (True, ["gpt-4", "claude-3"])
+
+    # Mock the config system
+    mock_codex_config = MagicMock()
+
+    # Mock load_config to return profile data with provider info
+    def mock_load_config(scope):
+        if scope == "user":
+            return {
+                "profiles": {
+                    "gpt-4": {"model": "gpt-4", "model_provider": "copilot-api"},
+                    "claude-3": {"model": "claude-3", "model_provider": "copilot-api"}
+                }
+            }
+        return {}
+
+    mock_codex_config.load_config.side_effect = mock_load_config
+
+    with patch(
+        "code_assistant_manager.tools.codex.upsert_codex_profile",
+        return_value={"changed": True, "provider_existed": False, "profile_existed": False, "project_existed": False},
+    ):
+        with patch.object(tool, "_ensure_tool_installed", return_value=True):
+            with patch.object(tool, "_read_existing_profiles", return_value=[]):
+                with patch("code_assistant_manager.configs.get_tool_config", return_value=mock_codex_config):
+                    # Mock all menu interactions
+                    menu_calls = []
+
+                    def mock_select_multiple_models(models, prompt, cancel_text=None):
+                        menu_calls.append({"type": "select_multiple", "models": models, "prompt": prompt})
+                        # Select claude-3 (index 1)
+                        return True, ["claude-3"]
+
+                    def mock_display_centered_menu(prompt, options, cancel_text=None):
+                        menu_calls.append({"type": "display_centered", "prompt": prompt, "options": options})
+                        # Select claude-3 profile (should be index 1)
+                        return True, 1
+
+                    with patch("code_assistant_manager.menu.menus.select_multiple_models", side_effect=mock_select_multiple_models):
+                        with patch("code_assistant_manager.menu.menus.display_centered_menu", side_effect=mock_display_centered_menu):
+                            captured = {}
+
+                            def _run(cmd, env, *_args, **_kwargs):
+                                captured["cmd"] = cmd
+                                return 0
+
+                            with patch.object(tool, "_run_tool_with_env", side_effect=_run):
+                                rc = tool.run([])
+
+    assert rc == 0
+    # Verify wire_api was unset for the correct provider
+    mock_codex_config.unset_value.assert_called_with("model_providers.copilot-api.wire_api", "user")


### PR DESCRIPTION
- Modified codex tool to set wire_api based on actual provider of selected profile
- Replaced hardcoded "copilot-api" with dynamic provider lookup
- Added unit tests for wire_api configuration behavior

This ensures wire_api is properly configured for the correct provider regardless of which endpoint serves GPT models.

Co-Authored-By: Claude (grok-code-fast-1) <noreply@anthropic.com>
