### PR TITLE
Add studiomeyer-marketplace (Memory, CRM, GEO, Crew)

### DIFF
--- a/code_assistant_manager/plugin_repos.json
+++ b/code_assistant_manager/plugin_repos.json
@@ -101,5 +101,14 @@
     "repoOwner": "thedotmack",
     "repoName": "claude-mem",
     "repoBranch": "main"
+  },
+  "studiomeyer-marketplace": {
+    "name": "studiomeyer-marketplace",
+    "description": "StudioMeyer MCP Suite for Claude Code \u2014 4 hosted plugins (Memory, CRM, GEO, Crew). 119 MCP tools, 21 slash commands, 5 skills, 3 subagents. Magic Link auth, EU Frankfurt. Free tier.",
+    "enabled": true,
+    "type": "marketplace",
+    "repoOwner": "studiomeyer-io",
+    "repoName": "studiomeyer-marketplace",
+    "repoBranch": "main"
   }
 }


### PR DESCRIPTION
Adds the StudioMeyer marketplace to `plugin_repos.json`.

**Repo:** https://github.com/studiomeyer-io/studiomeyer-marketplace

**Contents:**
- `studiomeyer-memory` — 53 tools, hosted AI memory with knowledge graph, semantic search, import from ChatGPT/Claude/Gemini/Copilot/Perplexity
- `studiomeyer-crm` — 33 tools, MCP-native CRM with companies, deals, pipeline, Stripe sync
- `studiomeyer-geo` — 23 tools, Generative Engine Optimization across 8 LLM platforms
- `studiomeyer-crew` — 10 tools + 8 agent personas + 3 multi-persona workflows

**Total:** 119 MCP tools, 21 slash commands, 5 skills, 3 subagents across 4 plugins.

**Auth:** OAuth 2.1 + Magic Link (no passwords)
**Hosting:** Supabase EU Frankfurt
**License:** MIT
**Free tier:** Every plugin has a free tier

Install:
```
/plugin marketplace add studiomeyer-io/studiomeyer-marketplace
/plugin install studiomeyer-memory@studiomeyer
```
