### PR TITLE
Add armoriq marketplace (ArmorClaude — security plugin)

### DIFF
--- a/code_assistant_manager/plugin_repos.json
+++ b/code_assistant_manager/plugin_repos.json
@@ -1,4 +1,13 @@
 {
+  "armoriq": {
+    "name": "armoriq",
+    "description": "ArmorIQ intent-based security enforcement for Claude Code: declared intent plans, natural-language policy rules, intent-drift blocking, optional CSRG cryptographic proofs, and central audit logging. Same model also ships for OpenAI Codex and GitHub Copilot CLI under the ArmorIQ marketplace.",
+    "enabled": true,
+    "type": "marketplace",
+    "repoOwner": "armoriq",
+    "repoName": "armorClaude",
+    "repoBranch": "main"
+  },
   "compounding-engineering": {
     "name": "compounding-engineering",
     "description": "A Claude Code plugin for compounding engineering practices",


### PR DESCRIPTION
## What

Adds the **armoriq** marketplace to \`plugin_repos.json\`. This is the official ArmorIQ marketplace for Claude Code security plugins, with one plugin published today (\`armorclaude\`).

## Install command

\`\`\`
cam plugin marketplace install armoriq
cam plugin install armorclaude
\`\`\`

## What armorclaude does

Intent-based security enforcement for Claude Code:

- Hooks: PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, PermissionRequest
- Registers the LLM's plan via MCP (\`register_intent_plan\` tool) before any tool fires
- Mints a signed intent JWT against the ArmorIQ backend
- Blocks tool calls that drift from the registered plan (intent drift detection)
- Policies managed in natural language via the \`policy_update\` MCP tool
- Optional CSRG cryptographic proofs (Merkle-tree-bound policy hashes)
- Central audit visible at \`platform.armoriq.ai\`

Plugin source: https://github.com/armoriq/armorClaude (main branch).

## Schema diff

One entry added to \`plugin_repos.json\`:

\`\`\`json
"armoriq": {
  "name": "armoriq",
  "description": "ArmorIQ intent-based security enforcement for Claude Code...",
  "enabled": true,
  "type": "marketplace",
  "repoOwner": "armoriq",
  "repoName": "armorClaude",
  "repoBranch": "main"
}
\`\`\`

Verified the marketplace.json at the source: https://github.com/armoriq/armorClaude/blob/main/.claude-plugin/marketplace.json

## Note

The same enforcement model also ships for OpenAI Codex (armorcodex) and GitHub Copilot CLI (armorcopilot) under their own repos. Adding only the Claude marketplace here since this list is curated for Claude Code plugins.