### PR TITLE
Add compass marketplace to plugin_repos.json

### DIFF
--- a/code_assistant_manager/plugin_repos.json
+++ b/code_assistant_manager/plugin_repos.json
@@ -110,5 +110,14 @@
     "repoOwner": "studiomeyer-io",
     "repoName": "studiomeyer-marketplace",
     "repoBranch": "main"
+  },
+  "compass": {
+    "name": "compass",
+    "description": "Eval-gated guardrails, red-team layer, cost-tier router, and SLSA-signed releases for Claude Code",
+    "enabled": true,
+    "type": "marketplace",
+    "repoOwner": "dshakes",
+    "repoName": "compass",
+    "repoBranch": "main"
   }
 }


### PR DESCRIPTION
Adds the [compass](https://github.com/dshakes/compass) marketplace (`.claude-plugin/marketplace.json` at repo root, version-pinned plugins `core` and `core-lsp`).

compass is an eval-gated trust layer for Claude Code: guardrail hooks that block catastrophic commands and secret writes before execution (100% precision/recall on a published 61-case corpus, enforced as a CI floor), a red-team layer for prompt-injection/context-poisoning detection (robust to base64/zero-width/homoglyph obfuscation), a measured cost-tier router, and SLSA-signed releases. MIT, no telemetry.

Verified locally: `claude plugin validate` passes on the marketplace manifest and both plugins. Entry appended in the existing format — happy to adjust.