### PR TITLE
feat(skills): restore 5 high-yield skill repos in catalog

### DIFF
--- a/code_assistant_manager/skill_repos.json
+++ b/code_assistant_manager/skill_repos.json
@@ -5,5 +5,35 @@
     "branch": "main",
     "enabled": true,
     "catalogFile": "FULL-SKILLS.md"
+  },
+  "jeremylongshore/claude-code-plugins-plus-skills": {
+    "owner": "jeremylongshore",
+    "name": "claude-code-plugins-plus-skills",
+    "branch": "main",
+    "enabled": true
+  },
+  "wshobson/agents": {
+    "owner": "wshobson",
+    "name": "agents",
+    "branch": "main",
+    "enabled": true
+  },
+  "anthropics/skills": {
+    "owner": "anthropics",
+    "name": "skills",
+    "branch": "main",
+    "enabled": true
+  },
+  "diet103/claude-code-infrastructure-showcase": {
+    "owner": "diet103",
+    "name": "claude-code-infrastructure-showcase",
+    "branch": "main",
+    "enabled": true
+  },
+  "obra/superpowers": {
+    "owner": "obra",
+    "name": "superpowers",
+    "branch": "main",
+    "enabled": true
   }
 }


### PR DESCRIPTION
## Summary
Re-add the source repositories that historically contributed ~3,800 skills to `Chat2AnyLLM/awesome-claude-skills`. They were dropped from this catalog at some point and are not present in `Chat2AnyLLM/awesome-repo-configs` either, which is why the awesome-claude-skills README dropped from ~10,300 to **2,974** skills.

## Restored repos
| Repo | Approx. skills contributed |
|---|---|
| `jeremylongshore/claude-code-plugins-plus-skills` | ~3,600 |
| `wshobson/agents` | ~156 |
| `anthropics/skills` | ~18 |
| `diet103/claude-code-infrastructure-showcase` | ~5 |
| `obra/superpowers` | ~14 |

## Expected effect
After merge + the next hourly cron run on `Chat2AnyLLM/awesome-claude-skills`, the README count should rise from **2,974** back to ~**6,800**.

## Note on `jeremylongshore/claude-code-plugins-plus`
GitHub now redirects this old name to `jeremylongshore/claude-code-plugins-plus-skills`, so we keep only the canonical name.