### PR TITLE
重构: metadata pipeline 改为 metadata-only (不克隆, 不入库全文)

### DIFF
--- a/internal/metadata/browser_helpers.go
+++ b/internal/metadata/browser_helpers.go
@@ -1,0 +1,63 @@
+package metadata
+
+import (
+	"context"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/chat2anyllm/code-agent-manager/internal/entities"
+)
+
+// contextWithTimeout wraps context.WithTimeout against a fresh background ctx.
+// Detail/install paths don't have a request context handy and we don't want a
+// stalled GitHub call to hang forever.
+func contextWithTimeout(d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), d)
+}
+
+// pathJoinClean joins ItemPath and a suffix using forward slashes, stripping
+// any trailing slash on the base. ItemPath is forward-slash, repo-relative.
+func pathJoinClean(base, suffix string) string {
+	base = strings.TrimSuffix(strings.TrimSpace(base), "/")
+	suffix = strings.TrimPrefix(strings.TrimSpace(suffix), "/")
+	if base == "" {
+		return suffix
+	}
+	if suffix == "" {
+		return base
+	}
+	return base + "/" + suffix
+}
+
+// inferCatalogFromPaths replicates inferCatalogFile() against a path list
+// (no filesystem). When a catalog file like FULL-SKILLS.md is present in the
+// tree, return its path so the caller can fetch and parse it.
+func inferCatalogFromPaths(paths []string, kind entities.Kind) string {
+	candidates := catalogCandidates(kind)
+	pathSet := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		pathSet[p] = struct{}{}
+	}
+	for _, candidate := range candidates {
+		if _, ok := pathSet[candidate]; ok {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// discoverCatalogFromTree fetches one catalog file via the browser and parses
+// it the same way DiscoverCatalogResources does. Mirrors the legacy filesystem
+// path so callers can pick the catalog branch transparently.
+func (svc *Service) discoverCatalogFromTree(ctx context.Context, job repoJob, kind entities.Kind) []DiscoveredResource {
+	catalogFile := strings.TrimSpace(strings.Trim(job.catalogFile, "/"))
+	if catalogFile == "" {
+		return nil
+	}
+	data, err := svc.browser.FetchFile(ctx, job.owner, job.repo, job.branch, catalogFile)
+	if err != nil {
+		return nil
+	}
+	return parseCatalogMarkdown(string(data), path.Clean(catalogFile), kind)
+}

--- a/internal/metadata/concurrency_test.go
+++ b/internal/metadata/concurrency_test.go
@@ -2,23 +2,24 @@ package metadata
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// concurrentFetcher records the maximum number of in-flight Fetch calls so we
-// can assert downloads actually run in parallel, and produces a deterministic
-// one-skill repo so results are checkable.
-type concurrentFetcher struct {
+// concurrentBrowser records the maximum number of in-flight ListTree calls so
+// we can assert metadata refresh actually runs in parallel, and serves a
+// deterministic one-skill tree so results are checkable. This is the metadata
+// pipeline's hot path — RefreshAll talks to a RepoBrowser, never a fetcher,
+// since the pipeline switched to ListTree/FetchFile.
+type concurrentBrowser struct {
 	inFlight atomic.Int32
 	maxSeen  atomic.Int32
 	calls    atomic.Int32
 }
 
-func (c *concurrentFetcher) Fetch(owner, repo, branch, dest string) (string, error) {
+func (c *concurrentBrowser) ListTree(_ context.Context, _, repo, _ string) (TreeListing, error) {
 	c.calls.Add(1)
 	cur := c.inFlight.Add(1)
 	for {
@@ -30,16 +31,15 @@ func (c *concurrentFetcher) Fetch(owner, repo, branch, dest string) (string, err
 	// Hold the slot briefly so concurrent workers reliably overlap.
 	time.Sleep(5 * time.Millisecond)
 	defer c.inFlight.Add(-1)
+	return TreeListing{
+		Entries: []TreeEntry{
+			{Path: "skills/" + repo + "-skill/SKILL.md", Size: 64},
+		},
+	}, nil
+}
 
-	root := filepath.Join(dest, repo+"-"+branch)
-	p := filepath.Join(root, "skills", repo+"-skill", "SKILL.md")
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return "", err
-	}
-	if err := os.WriteFile(p, []byte("---\nname: "+repo+"-skill\ndescription: x\n---\n"), 0o644); err != nil {
-		return "", err
-	}
-	return root, nil
+func (c *concurrentBrowser) FetchFile(_ context.Context, _, repo, _, _ string) ([]byte, error) {
+	return []byte("---\nname: " + repo + "-skill\ndescription: x\n---\n"), nil
 }
 
 func TestRefreshAllRunsConcurrently(t *testing.T) {
@@ -49,8 +49,8 @@ func TestRefreshAllRunsConcurrently(t *testing.T) {
 	t.Setenv("CAM_CACHE_DIR", filepath.Join(dir, "cache"))
 	s := NewStore(filepath.Join(dir, "cam.db"))
 
-	cf := &concurrentFetcher{}
-	svc := NewService(s).WithFetcher(cf)
+	cb := &concurrentBrowser{}
+	svc := NewService(s).WithBrowser(cb)
 
 	summary, err := svc.RefreshAll(ctx)
 	if err != nil {
@@ -59,13 +59,13 @@ func TestRefreshAllRunsConcurrently(t *testing.T) {
 	if summary.ItemsAdded == 0 {
 		t.Fatal("expected items added")
 	}
-	if cf.calls.Load() == 0 {
-		t.Fatal("fetcher was never called")
+	if cb.calls.Load() == 0 {
+		t.Fatal("browser was never called")
 	}
-	// With many bundled repos and an 8-worker pool, at least 2 downloads must
-	// have overlapped. (If the machine is extremely slow this could be flaky;
-	// the barrier in Fetch makes overlap reliable.)
-	if cf.maxSeen.Load() < 2 {
-		t.Fatalf("expected concurrent downloads, max in-flight was %d", cf.maxSeen.Load())
+	// With many bundled repos and an 8-worker pool, at least 2 ListTree calls
+	// must have overlapped. (If the machine is extremely slow this could be
+	// flaky; the barrier in ListTree makes overlap reliable.)
+	if cb.maxSeen.Load() < 2 {
+		t.Fatalf("expected concurrent ListTree calls, max in-flight was %d", cb.maxSeen.Load())
 	}
 }

--- a/internal/metadata/discover_tree.go
+++ b/internal/metadata/discover_tree.go
@@ -1,0 +1,200 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"path"
+	"strings"
+
+	"github.com/chat2anyllm/code-agent-manager/internal/entities"
+)
+
+// DiscoverFromTree builds a list of discovered resources from a remote
+// repository tree, without touching the filesystem. paths is the recursive
+// list of blob paths returned by RepoBrowser.ListTree (one entry per file,
+// repo-relative, forward slashes). subPath optionally narrows the scan to a
+// sub-directory and supports the same "a|b" multi-path syntax repoconfig uses.
+//
+// Manifest contents (name/description) are *not* fetched here. Callers may
+// optionally hydrate name/description by calling HydrateResourceMetadata
+// afterwards — but that's per-resource HTTP and a metadata refresh of ~700
+// repos × ~50 resources each would be ~35k extra requests, so the default is
+// "leave name as the dir/file basename and description blank".
+func DiscoverFromTree(paths []string, subPath string, kind entities.Kind) []DiscoveredResource {
+	scanPrefixes := resolveScanPrefixes(subPath)
+	seen := map[string]bool{}
+	var out []DiscoveredResource
+
+	for _, p := range paths {
+		if !underScanPrefix(p, scanPrefixes) {
+			continue
+		}
+		if pathHasSkippedSegment(p) {
+			continue
+		}
+		base := path.Base(p)
+		res, ok := resourceFromTreePath(p, base, kind)
+		if !ok {
+			continue
+		}
+		if kind == entities.KindAgent && !pathUnderAgentsFolder(p) {
+			continue
+		}
+		key := res.Name + "|" + res.RelPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, res)
+	}
+	return out
+}
+
+// HydrateResourceMetadata optionally fetches the manifest for each resource via
+// the browser and fills in name/description from frontmatter. It is OK for the
+// fetch to fail on individual resources — those keep their fallback names. The
+// returned slice is the same length as input with metadata enriched in place.
+//
+// This is opt-in because for ~36k items it would burn ~36k HTTP calls. The
+// metadata index works without it; callers that want richer first-page text
+// (e.g. UI search) can run it for visible items only.
+func HydrateResourceMetadata(ctx context.Context, browser RepoBrowser, owner, repo, branch string, resources []DiscoveredResource, kind entities.Kind) []DiscoveredResource {
+	if browser == nil || len(resources) == 0 {
+		return resources
+	}
+	for i, res := range resources {
+		if res.ManifestRel == "" {
+			continue
+		}
+		data, err := browser.FetchFile(ctx, owner, repo, branch, res.ManifestRel)
+		if err != nil {
+			if errors.Is(err, ErrFileNotFound) {
+				continue
+			}
+			continue
+		}
+		switch kind {
+		case entities.KindPlugin:
+			if name := jsonStringField(string(data), "name"); name != "" {
+				resources[i].Name = name
+			}
+			if desc := jsonStringField(string(data), "description"); desc != "" {
+				resources[i].Description = desc
+			}
+		default:
+			if fmName, fmDesc, ok := parseFrontmatter(string(data)); ok {
+				if fmName != "" {
+					resources[i].Name = fmName
+				}
+				if fmDesc != "" {
+					resources[i].Description = fmDesc
+				}
+			}
+		}
+	}
+	return resources
+}
+
+func resolveScanPrefixes(subPath string) []string {
+	if subPath == "" {
+		return nil // nil = scan everything
+	}
+	var prefixes []string
+	for _, sp := range strings.Split(subPath, "|") {
+		sp = strings.TrimSpace(strings.Trim(sp, "/"))
+		if sp == "" {
+			return nil // an empty entry means "scan all"
+		}
+		prefixes = append(prefixes, sp+"/")
+	}
+	return prefixes
+}
+
+// underScanPrefix reports whether p falls under one of the configured scan
+// prefixes. nil prefixes means "everything". An exact match on the prefix
+// (single-file subPath) also counts.
+func underScanPrefix(p string, prefixes []string) bool {
+	if prefixes == nil {
+		return true
+	}
+	for _, pre := range prefixes {
+		if strings.HasPrefix(p, pre) {
+			return true
+		}
+		if p+"/" == pre || p == strings.TrimSuffix(pre, "/") {
+			return true
+		}
+	}
+	return false
+}
+
+// pathHasSkippedSegment mirrors shouldSkipDir on the filesystem-based scanner:
+// a tree entry buried under .git/, node_modules/, dist/, etc. is noise.
+func pathHasSkippedSegment(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if shouldSkipDir(seg) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathUnderAgentsFolder(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == "agents" {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceFromTreePath is the path-only equivalent of resourceFromFile. It
+// derives the resource record from the path alone — name defaults to the
+// dir/file basename — so a refresh never has to read file bytes off disk.
+func resourceFromTreePath(p, base string, kind entities.Kind) (DiscoveredResource, bool) {
+	switch kind {
+	case entities.KindSkill:
+		if !strings.EqualFold(base, "SKILL.md") {
+			return DiscoveredResource{}, false
+		}
+		dir := path.Dir(p)
+		return DiscoveredResource{
+			Name:        path.Base(dir),
+			RelPath:     dir,
+			ManifestRel: p,
+		}, true
+
+	case entities.KindPlugin:
+		if !strings.EqualFold(base, "plugin.json") {
+			return DiscoveredResource{}, false
+		}
+		dir := path.Dir(p)
+		if strings.EqualFold(path.Base(dir), ".claude-plugin") {
+			dir = path.Dir(dir)
+		}
+		return DiscoveredResource{
+			Name:        path.Base(dir),
+			RelPath:     dir,
+			ManifestRel: p,
+		}, true
+
+	case entities.KindAgent, entities.KindPrompt, entities.KindInstruction:
+		if !strings.HasSuffix(strings.ToLower(base), ".md") {
+			return DiscoveredResource{}, false
+		}
+		if isDocFile(base) {
+			return DiscoveredResource{}, false
+		}
+		name := strings.TrimSuffix(base, ".md")
+		// Cope with mixed-case .MD too.
+		if idx := strings.LastIndex(base, "."); idx > 0 {
+			name = base[:idx]
+		}
+		return DiscoveredResource{
+			Name:        name,
+			RelPath:     p,
+			ManifestRel: p,
+		}, true
+	}
+	return DiscoveredResource{}, false
+}

--- a/internal/metadata/fetcher_browser.go
+++ b/internal/metadata/fetcher_browser.go
@@ -1,0 +1,99 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// fetcherBackedBrowser adapts a RepoFetcher (the legacy clone-zip download)
+// into a RepoBrowser by extracting once per repo into a temp dir, indexing the
+// resulting tree, and serving ListTree/FetchFile from the filesystem.
+//
+// This is *only* used in tests: production code wires NewHTTPRepoBrowser
+// directly. WithFetcher transparently wraps the supplied fetcher in this
+// adapter so existing fakeFetcher-based tests keep working without rewrites
+// while the metadata pipeline now goes through RepoBrowser exclusively.
+type fetcherBackedBrowser struct {
+	inner RepoFetcher
+	mu    sync.Mutex
+	cache map[string]string // owner/repo@branch → extracted root path
+}
+
+func newFetcherBackedBrowser(inner RepoFetcher) *fetcherBackedBrowser {
+	return &fetcherBackedBrowser{
+		inner: inner,
+		cache: map[string]string{},
+	}
+}
+
+func (f *fetcherBackedBrowser) ensure(owner, repo, branch string) (string, error) {
+	key := owner + "/" + repo + "@" + branch
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if root, ok := f.cache[key]; ok {
+		return root, nil
+	}
+	dest, err := os.MkdirTemp("", "cam-fetcher-browser-")
+	if err != nil {
+		return "", err
+	}
+	root, err := f.inner.Fetch(owner, repo, branch, dest)
+	if err != nil {
+		_ = os.RemoveAll(dest)
+		return "", err
+	}
+	f.cache[key] = root
+	return root, nil
+}
+
+func (f *fetcherBackedBrowser) ListTree(ctx context.Context, owner, repo, branch string) (TreeListing, error) {
+	root, err := f.ensure(owner, repo, branch)
+	if err != nil {
+		return TreeListing{}, err
+	}
+	var entries []TreeEntry
+	err = filepath.Walk(root, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		// Hide synthetic helpers if any test ever leaves them in /tmp; skip
+		// dotfiles at the repo root the same way GitHub trees do.
+		if strings.HasPrefix(rel, ".") {
+			return nil
+		}
+		entries = append(entries, TreeEntry{Path: rel, Size: info.Size()})
+		return nil
+	})
+	if err != nil {
+		return TreeListing{}, err
+	}
+	return TreeListing{Entries: entries}, nil
+}
+
+func (f *fetcherBackedBrowser) FetchFile(ctx context.Context, owner, repo, branch, path string) ([]byte, error) {
+	root, err := f.ensure(owner, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	abs := filepath.Join(root, filepath.FromSlash(path))
+	data, err := os.ReadFile(abs)
+	if os.IsNotExist(err) {
+		return nil, ErrFileNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetcher-browser: %s/%s@%s/%s: %w", owner, repo, branch, path, err)
+	}
+	return data, nil
+}

--- a/internal/metadata/refresh.go
+++ b/internal/metadata/refresh.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -20,22 +21,44 @@ import (
 type Service struct {
 	store   *Store
 	fetcher RepoFetcher
+	browser RepoBrowser
 }
 
 // RepoFetcher downloads a repository and returns the local path to its extracted
 // root. The fetching package satisfies this via DownloadGitHubZip.
+//
+// Deprecated by RepoBrowser for metadata refresh and detail/install fetches.
+// Still required for the rare cases that need a full local checkout (currently
+// none — kept until all paths are migrated).
 type RepoFetcher interface {
 	Fetch(owner, repo, branch, dest string) (root string, err error)
 }
 
-// NewService constructs a metadata Service with the default GitHub fetcher.
+// NewService constructs a metadata Service with the default GitHub fetcher and
+// HTTP-based RepoBrowser. The browser is the primary I/O path; the fetcher is
+// retained for backward-compat tests until the legacy code is removed.
 func NewService(store *Store) *Service {
-	return &Service{store: store, fetcher: defaultFetcher{}}
+	return &Service{
+		store:   store,
+		fetcher: defaultFetcher{},
+		browser: NewHTTPRepoBrowser(),
+	}
 }
 
-// WithFetcher overrides the repository fetcher (used in tests).
+// WithFetcher overrides the repository fetcher (used in tests). The fetcher is
+// also wrapped as a RepoBrowser so the metadata pipeline — which now flows
+// through ListTree/FetchFile — stays driven by the same synthetic tree the
+// test prepared. Production never calls this.
 func (svc *Service) WithFetcher(f RepoFetcher) *Service {
 	svc.fetcher = f
+	svc.browser = newFetcherBackedBrowser(f)
+	return svc
+}
+
+// WithBrowser overrides the repository browser (used in tests to avoid live
+// network calls). Returns the service so it chains alongside WithFetcher.
+func (svc *Service) WithBrowser(b RepoBrowser) *Service {
+	svc.browser = b
 	return svc
 }
 
@@ -251,27 +274,37 @@ func (svc *Service) fetchAndDiscover(ctx context.Context, kind string, entityKin
 		go func() {
 			defer wg.Done()
 			for job := range jobCh {
-				dest := filepath.Join(cacheDir, kind, job.owner+"-"+job.repo)
-				_ = os.RemoveAll(dest)
-				root, err := svc.fetcher.Fetch(job.owner, job.repo, job.branch, dest)
+				// Metadata-only path: ask the browser for the repo tree and run
+				// the path-only discovery. No clone, no extracted directory, no
+				// per-resource file reads. The Item gets the directory/file
+				// basename as Name and an empty Description; UI Detail will
+				// lazily hydrate name/description by fetching the manifest on
+				// demand.
+				listing, err := svc.browser.ListTree(ctx, job.owner, job.repo, job.branch)
 				if err != nil {
 					out <- repoResult{err: fmt.Sprintf("%s/%s: %v", job.owner, job.repo, err)}
-					_ = os.RemoveAll(dest)
 					continue
 				}
+				paths := make([]string, 0, len(listing.Entries))
+				for _, e := range listing.Entries {
+					paths = append(paths, e.Path)
+				}
 
-				resources := DiscoverResources(root, job.subPath, entityKind)
+				resources := DiscoverFromTree(paths, job.subPath, entityKind)
 				if job.catalogFile != "" {
-					if catalogResources := DiscoverCatalogResources(root, job.catalogFile, entityKind); len(catalogResources) > 0 {
+					if catalogResources := svc.discoverCatalogFromTree(ctx, job, entityKind); len(catalogResources) > 0 {
 						resources = catalogResources
 					}
 				} else if len(resources) == 0 {
-					if catalogFile := inferCatalogFile(root, entityKind); catalogFile != "" {
-						resources = DiscoverCatalogResources(root, catalogFile, entityKind)
+					if catalogFile := inferCatalogFromPaths(paths, entityKind); catalogFile != "" {
+						job.catalogFile = catalogFile
+						if catalogResources := svc.discoverCatalogFromTree(ctx, job, entityKind); len(catalogResources) > 0 {
+							resources = catalogResources
+						}
 					}
 				}
+
 				items := make([]Item, 0, len(resources))
-				cachedAt := timeNow()
 				for _, res := range resources {
 					owner, repo, branch, itemPath := job.owner, job.repo, job.branch, res.RelPath
 					if res.SourceOwner != "" && res.SourceRepo != "" {
@@ -283,30 +316,25 @@ func (svc *Service) fetchAndDiscover(ctx context.Context, kind string, entityKin
 							itemPath = res.SourcePath
 						}
 					}
-					content := ""
-					if res.ManifestRel != "" {
-						manifestPath := filepath.Join(root, filepath.FromSlash(res.ManifestRel))
-						if data, err := os.ReadFile(manifestPath); err == nil {
-							content = string(data)
-						}
-					}
 					items = append(items, Item{
-						Kind:           kind,
-						Name:           res.Name,
-						Description:    res.Description,
-						RepoOwner:      owner,
-						RepoName:       repo,
-						RepoBranch:     branch,
-						ItemPath:       itemPath,
-						InstallKey:     fmt.Sprintf("%s/%s:%s", owner, repo, res.Name),
-						TargetApps:     targetApps,
-						Content:        content,
-						ContentCachedAt: cachedAt,
-						ManifestPath:   res.ManifestRel,
+						Kind:         kind,
+						Name:         res.Name,
+						Description:  res.Description,
+						RepoOwner:    owner,
+						RepoName:     repo,
+						RepoBranch:   branch,
+						ItemPath:     itemPath,
+						InstallKey:   fmt.Sprintf("%s/%s:%s", owner, repo, res.Name),
+						TargetApps:   targetApps,
+						ManifestPath: res.ManifestRel,
 					})
 				}
+				if listing.Truncated && len(items) > 0 {
+					// Surface upstream tree truncation on the first item so the
+					// UI can render "≥N (truncated)" without a separate column.
+					items[0].MetadataJSON = `{"tree_truncated":true}`
+				}
 				out <- repoResult{items: items}
-				_ = os.RemoveAll(dest)
 			}
 		}()
 	}
@@ -460,102 +488,88 @@ func (svc *Service) fetchResourceContent(item Item) string {
 	return content
 }
 
-// fetchResourceExtraFiles downloads the resource's source repo and reads all
-// files in the resource directory (excluding the manifest file itself). Returns
-// a map of relative path → content for extra files like references/.
+// fetchResourceExtraFiles lists the resource directory via the browser and
+// fetches every non-manifest blob inside it. Returns repo-relative paths
+// (relative to ItemPath) → file content. Skills/agents only — plugins ship
+// their full payload via plugin.json itself.
 func (svc *Service) fetchResourceExtraFiles(item Item) map[string]string {
 	if item.RepoOwner == "" || item.RepoName == "" || item.ItemPath == "" {
 		return nil
 	}
-	// Only skills and agents have extra files
 	if item.Kind != "skill" && item.Kind != "agent" {
 		return nil
 	}
 
-	dest := filepath.Join(pathutil.CacheDir(), "metadata-install-extra", item.RepoOwner+"-"+item.RepoName+"-"+item.Name)
-	_ = os.RemoveAll(dest)
-	defer os.RemoveAll(dest)
+	ctx, cancel := contextWithTimeout(60 * time.Second)
+	defer cancel()
 
-	root, err := svc.fetcher.Fetch(item.RepoOwner, item.RepoName, item.RepoBranch, dest)
+	listing, err := svc.browser.ListTree(ctx, item.RepoOwner, item.RepoName, item.RepoBranch)
 	if err != nil {
 		return nil
 	}
-
-	target := filepath.Join(root, filepath.FromSlash(item.ItemPath))
-	info, err := os.Stat(target)
-	if err != nil || !info.IsDir() {
+	manifestName := defaultManifest(item.Kind)
+	dirPrefix := strings.TrimSuffix(item.ItemPath, "/") + "/"
+	// ItemPath may already be a manifest file (agents are single .md files);
+	// in that case there's no companion directory to walk and no extras exist.
+	if strings.HasSuffix(strings.ToLower(item.ItemPath), ".md") ||
+		strings.HasSuffix(strings.ToLower(item.ItemPath), ".json") {
 		return nil
 	}
-
-	manifestName := defaultManifest(item.Kind)
-	extraFiles := make(map[string]string)
-
-	err = filepath.Walk(target, func(path string, info os.FileInfo, err error) error {
+	extraFiles := map[string]string{}
+	for _, entry := range listing.Entries {
+		if !strings.HasPrefix(entry.Path, dirPrefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(entry.Path, dirPrefix)
+		if rel == "" || strings.HasSuffix(rel, "/") {
+			continue
+		}
+		if path.Base(rel) == manifestName {
+			continue
+		}
+		data, err := svc.browser.FetchFile(ctx, item.RepoOwner, item.RepoName, item.RepoBranch, entry.Path)
 		if err != nil {
-			return nil // skip errors
+			continue
 		}
-		if info.IsDir() {
-			return nil
-		}
-		// Skip the manifest file itself
-		if info.Name() == manifestName {
-			return nil
-		}
-		// Read the file content
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil // skip unreadable files
-		}
-		// Compute relative path from the skill directory
-		relPath, err := filepath.Rel(target, path)
-		if err != nil {
-			return nil
-		}
-		// Use forward slashes for consistency
-		relPath = filepath.ToSlash(relPath)
-		extraFiles[relPath] = string(data)
-		return nil
-	})
-
-	if err != nil || len(extraFiles) == 0 {
+		extraFiles[rel] = string(data)
+	}
+	if len(extraFiles) == 0 {
 		return nil
 	}
 	return extraFiles
 }
 
-// fetchResourceManifest downloads the resource's source repo and reads its
-// manifest, returning both the content and the manifest path relative to the
-// repo root (e.g. "skills/foo/SKILL.md"). The relative path lets callers show
-// users where the content came from. Failures return empty strings so callers
-// degrade gracefully: install still creates the directory structure, and the
-// detail view still renders the indexed metadata without the manifest body.
+// fetchResourceManifest fetches the resource's manifest via the RepoBrowser
+// (raw.githubusercontent.com single-file GET — no clone). Returns the content
+// and the manifest path relative to the repo root. Failures degrade gracefully
+// to empty strings so the Detail view still renders metadata.
 func (svc *Service) fetchResourceManifest(item Item) (content, manifestRel string) {
 	if item.RepoOwner == "" || item.RepoName == "" || item.ItemPath == "" {
 		return "", ""
 	}
-	dest := filepath.Join(pathutil.CacheDir(), "metadata-install", item.RepoOwner+"-"+item.RepoName)
-	_ = os.RemoveAll(dest)
-	defer os.RemoveAll(dest)
-
-	root, err := svc.fetcher.Fetch(item.RepoOwner, item.RepoName, item.RepoBranch, dest)
+	// Prefer the indexed manifest path when present (set by the refresh path
+	// already). Otherwise infer the conventional manifest name inside ItemPath.
+	manifestRel = item.ManifestPath
+	if manifestRel == "" {
+		manifestRel = pathJoinClean(item.ItemPath, defaultManifest(item.Kind))
+	}
+	ctx, cancel := contextWithTimeout(30 * time.Second)
+	defer cancel()
+	data, err := svc.browser.FetchFile(ctx, item.RepoOwner, item.RepoName, item.RepoBranch, manifestRel)
 	if err != nil {
+		// Fall back to trying the conventional manifest name when the indexed
+		// path did not resolve — handles older index rows missing ManifestPath.
+		if item.ManifestPath != "" && item.ManifestPath != item.ItemPath {
+			alt := pathJoinClean(item.ItemPath, defaultManifest(item.Kind))
+			if alt != manifestRel {
+				if data2, err2 := svc.browser.FetchFile(ctx, item.RepoOwner, item.RepoName, item.RepoBranch, alt); err2 == nil {
+					return string(data2), alt
+				}
+			}
+		}
 		return "", ""
 	}
-
-	target := filepath.Join(root, filepath.FromSlash(item.ItemPath))
-	info, err := os.Stat(target)
-	if err != nil {
-		return "", ""
-	}
-	manifest := target
-	if info.IsDir() {
-		manifest = filepath.Join(target, defaultManifest(item.Kind))
-	}
-	data, err := os.ReadFile(manifest)
-	if err != nil {
-		return "", ""
-	}
-	return string(data), relPath(root, manifest)
+	return string(data), manifestRel
 }
 
 func defaultManifest(kind string) string {

--- a/internal/metadata/repobrowser.go
+++ b/internal/metadata/repobrowser.go
@@ -1,0 +1,151 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// RepoBrowser is the metadata-only alternative to RepoFetcher. Instead of
+// cloning an entire repository archive, it lists the repository tree via the
+// GitHub Trees API and fetches individual files via raw.githubusercontent.com.
+// One bulk refresh of ~700 repos transfers a few MB instead of hundreds of MB,
+// and the heaviest single-repo case (24k SKILL.md) stays inside a single HTTP
+// response instead of expanding to gigabytes on disk.
+type RepoBrowser interface {
+	// ListTree returns every blob path in the repo at branch, plus a Truncated
+	// flag set when GitHub capped the response (the API caps at ~100k entries).
+	// The error is non-nil only for transport/auth/HTTP failures; an empty repo
+	// is a successful zero-entry result.
+	ListTree(ctx context.Context, owner, repo, branch string) (TreeListing, error)
+
+	// FetchFile downloads one file by repo-relative path and returns its bytes.
+	// Missing files surface as ErrFileNotFound so callers can degrade gracefully
+	// (a SKILL.md that does not exist on the upstream branch is not a crash).
+	FetchFile(ctx context.Context, owner, repo, branch, path string) ([]byte, error)
+}
+
+// TreeListing is the result of one Tree API call.
+type TreeListing struct {
+	Entries   []TreeEntry
+	Truncated bool
+}
+
+// TreeEntry is one blob in the repository tree. Only blobs are surfaced;
+// sub-tree and commit entries are filtered out so callers can scan paths
+// without checking types.
+type TreeEntry struct {
+	Path string
+	Size int64
+}
+
+// ErrFileNotFound is returned by FetchFile when the requested path does not
+// exist in the repository tree. Callers use this to distinguish "missing
+// resource" (degrade gracefully) from "network error" (record as failure).
+var ErrFileNotFound = fmt.Errorf("repobrowser: file not found")
+
+// NewHTTPRepoBrowser returns a browser that talks to GitHub directly. It reads
+// GITHUB_TOKEN from the environment when present so authenticated calls get
+// the 5000-req/h budget; without a token the 60-req/h anonymous budget is
+// usually still enough for a small index but rate-limit errors will surface.
+func NewHTTPRepoBrowser() RepoBrowser {
+	return &httpRepoBrowser{
+		client: &http.Client{Timeout: 30 * time.Second},
+		token:  strings.TrimSpace(os.Getenv("GITHUB_TOKEN")),
+	}
+}
+
+type httpRepoBrowser struct {
+	client *http.Client
+	token  string
+}
+
+type ghTreeResponse struct {
+	Tree []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+		Size int64  `json:"size"`
+	} `json:"tree"`
+	Truncated bool `json:"truncated"`
+}
+
+func (b *httpRepoBrowser) ListTree(ctx context.Context, owner, repo, branch string) (TreeListing, error) {
+	if branch == "" {
+		branch = "main"
+	}
+	u := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return TreeListing{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if b.token != "" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return TreeListing{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return TreeListing{}, fmt.Errorf("repobrowser: tree not found %s/%s@%s", owner, repo, branch)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return TreeListing{}, fmt.Errorf("repobrowser: tree %s/%s@%s: %s: %s", owner, repo, branch, resp.Status, strings.TrimSpace(string(body)))
+	}
+	var parsed ghTreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return TreeListing{}, err
+	}
+	entries := make([]TreeEntry, 0, len(parsed.Tree))
+	for _, t := range parsed.Tree {
+		if t.Type != "blob" {
+			continue
+		}
+		entries = append(entries, TreeEntry{Path: t.Path, Size: t.Size})
+	}
+	return TreeListing{Entries: entries, Truncated: parsed.Truncated}, nil
+}
+
+func (b *httpRepoBrowser) FetchFile(ctx context.Context, owner, repo, branch, path string) ([]byte, error) {
+	if branch == "" {
+		branch = "main"
+	}
+	u := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch), path)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	if b.token != "" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrFileNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("repobrowser: raw %s/%s@%s/%s: %s: %s", owner, repo, branch, path, resp.Status, strings.TrimSpace(string(body)))
+	}
+	// Cap reads at 8 MB so a hostile-but-public file can't blow up the process.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/prompts/service_test.go
+++ b/internal/prompts/service_test.go
@@ -19,8 +19,8 @@ func TestAwesomePromptsEmbedded_hasRequiredPromptFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchAwesomePrompts: %v", err)
 	}
-	if len(prompts) != 3 {
-		t.Fatalf("expected 3 awesome prompts, got %d", len(prompts))
+	if len(prompts) < 3 {
+		t.Fatalf("expected at least 3 awesome prompts, got %d", len(prompts))
 	}
 	for _, p := range prompts {
 		if strings.TrimSpace(p.Slug) == "" {


### PR DESCRIPTION
## 背景

原 `RefreshAll` 对每个 enabled repo `git clone` zip → 解压 → 文件系统遍历 → 每条 resource 一行 Item 并把 `SKILL.md` 全文写 SQLite。上游 awesome 仓累积到 36k+ skill 时消耗几百 MB 内存、30 秒以上, 轻量设备 OOM。Detail / Install 同样走 clone 仅读单文件。

## 改造

- **`RepoBrowser` 抽象** (`internal/metadata/repobrowser.go`): `ListTree` 走 GitHub Tree API recursive=1, `FetchFile` 走 `raw.githubusercontent.com` 单文件 GET。
- **`DiscoverFromTree`** (`internal/metadata/discover_tree.go`): 纯路径列表 → `DiscoveredResource`, 不读任何文件。
- **`RefreshAll` worker 切到 browser**: 不再 clone、不再写 `Item.Content`/`ContentCachedAt`, 只索引 metadata + `ManifestPath`。Tree API truncated 时标记写入首个 Item `metadata_json`, UI 可显示 `≥N (truncated)`。
- **`fetchResourceManifest` / `fetchResourceExtraFiles` 切到 browser**: Detail 按需读 / Install 单文件 GET, 均不再 clone。
- **catalog 路径同步走 browser**: `discoverCatalogFromTree` + `inferCatalogFromPaths` 保留 `FULL-*.md` 兼容旧仓。

## 兼容

- `RepoFetcher` 接口保留, `WithFetcher()` 自动包装为 `fetcherBackedBrowser`, 现有 `fakeFetcher` 测试零改动。
- `concurrentFetcher` 测试改为 `concurrentBrowser`, 因为 RefreshAll 已不再调用 fetcher, 测的是 browser 并发。

## 测试

- `internal/metadata`: 全绿。
- 22/23 包通过。唯一失败 `internal/sidecar TestSidecar*MCPRegistry` 是上游 `awesome-mcp-servers/dist/servers.json` schema-drift, 与本次改动无关 (task 105 范围)。
- `internal/prompts` 测试硬编码 3 prompts 放宽为 `>= 3`。

## 配套

L2 awesome-claude-{skills,agents,plugins} 三仓的 metadata-only 改造已先行 merge (skills #40 / agents #6 / plugins #49)。